### PR TITLE
Add support for Paths that end in / like http://test.com/ControllerName/

### DIFF
--- a/src/cloudscribe.Web.Navigation/TreeNodeExtensions.cs
+++ b/src/cloudscribe.Web.Navigation/TreeNodeExtensions.cs
@@ -66,9 +66,15 @@ namespace cloudscribe.Web.Navigation
                 if ((!string.IsNullOrEmpty(n.Value.Action))&& (!string.IsNullOrEmpty(n.Value.Controller)))
                 {
                     targetUrl = urlHelper.Action(n.Value.Action, n.Value.Controller, new { area = n.Value.Area });
+
                     if (targetUrl == null) return false; // check for null in case action cannot be resolved
+                    if (urlToMatch.EndsWith("/"))
+                    {
+                        targetUrl = targetUrl + "/";
+                    }
                     if (targetUrl.IndexOf(urlToMatch, StringComparison.OrdinalIgnoreCase) >= 0)
                     { return true; }
+                    
                 }
 
                 if ((!string.IsNullOrWhiteSpace(urlPrefix))&&(!string.IsNullOrWhiteSpace(n.Value.Url)))


### PR DESCRIPTION
If we have a record like:

Controller=ControllerName Action=Index

and we use this path:

Http://www/ControllerName   -  We find the node
Http://www/ControllerName/Index   -  We find the node
Http://www/ControllerName/  -  We do not find the node


This pr fixes the last example that while valid in mvc does not work with cloud scribe