### PR TITLE
Added "separator" functionality for bootstrap 4 dropdown menu

### DIFF
--- a/src/NavigationDemo.Web/navigation.xml
+++ b/src/NavigationDemo.Web/navigation.xml
@@ -36,6 +36,7 @@
             <NavNode key="areahome" area="Area51" controller="Home" action="Index" preservedRouteParameters="culture" text="Home">
               <Children />
             </NavNode>
+            <NavNode key="areaseparator" text="Separator"></NavNode>
               <NavNode key="aliens" area="Area51" controller="Roswell" action="Aliens" preservedRouteParameters="culture" text="Aliens">
                   <Children />
               </NavNode>

--- a/src/cloudscribe.Web.Navigation/Views/Shared/Bootstrap4NavigationNodeChildDropdownPartial.cshtml
+++ b/src/cloudscribe.Web.Navigation/Views/Shared/Bootstrap4NavigationNodeChildDropdownPartial.cshtml
@@ -6,24 +6,25 @@
 @inject IStringLocalizer<cloudscribe.Web.Navigation.MenuResources> sr
 @if ((Model.TempNode != null) && (await Model.HasVisibleChildren(Model.TempNode)))
 {
-    <ul class="dropdown-menu" aria-labelledby="dropdown-@Model.TempNode.Value.Key">
-        @foreach (var childNode in Model.TempNode.Children)
-        {
-            if (! await Model.ShouldAllowView(childNode)) { continue; }
+<ul class="dropdown-menu" aria-labelledby="dropdown-@Model.TempNode.Value.Key">
+    @foreach (var childNode in Model.TempNode.Children) {
+        if (!await Model.ShouldAllowView(childNode)) { continue; }
 
-            if (! await Model.HasVisibleChildren(childNode))
-            {
-                <li class='@Model.GetClass(childNode.Value, "")'><a class="dropdown-item" href="@Url.Content(Model.AdjustUrl(childNode))">@Html.Raw(Model.GetIcon(childNode.Value))@sr[Model.AdjustText(childNode)]</a></li>
-            }
-            else
-            {
-
-                <li class='@Model.GetClass(childNode.Value, "dropdown ",  "active", true)'>
-                    <a class="dropdown-item dropdown-toggle" href="@Url.Content(Model.AdjustUrl(childNode))">@Html.Raw(Model.GetIcon(childNode.Value))@sr[Model.AdjustText(childNode)] </a>
-                    @Model.UpdateTempNode(childNode) <partial name="Bootstrap4NavigationNodeChildDropdownPartial" model="@Model" />   @* recursion *@
-                </li>
-
-            }
+        if (childNode.Value.Text == "Separator") {
+            <div class="dropdown-divider"></div>
+            continue;
         }
-    </ul>
+        if (!await Model.HasVisibleChildren(childNode)) {
+            <li class='@Model.GetClass(childNode.Value, "")'><a class="dropdown-item" href="@Url.Content(Model.AdjustUrl(childNode))">@Html.Raw(Model.GetIcon(childNode.Value))@sr[Model.AdjustText(childNode)]</a></li>
+        }
+        else {
+
+            <li class='@Model.GetClass(childNode.Value, "dropdown ",  "active", true)'>
+                <a class="dropdown-item dropdown-toggle" href="@Url.Content(Model.AdjustUrl(childNode))">@Html.Raw(Model.GetIcon(childNode.Value))@sr[Model.AdjustText(childNode)] </a>
+                @Model.UpdateTempNode(childNode) <partial name="Bootstrap4NavigationNodeChildDropdownPartial" model="@Model" />   @* recursion *@
+            </li>
+
+        }
+    }
+</ul>
 }


### PR DESCRIPTION
I needed a seaparator in a bootstrap4 menu but found this was not working.

I copied the functionality from NavigationNodeChildDropdownPartial to Bootstrap4NavigationNodeChildDropdownPartial and modified the html for bootrap4

I added a separator in the menu of the demo project for testing and as an example
